### PR TITLE
Improve escaping.

### DIFF
--- a/src/gocept/template_rewrite/pagetemplates.py
+++ b/src/gocept/template_rewrite/pagetemplates.py
@@ -153,7 +153,7 @@ class HTMLGenerator(html.parser.HTMLParser):
 
     # Overridable -- handle data
     def handle_data(self, data):
-        self._cont_handler.characters(data)
+        self._write_raw(data)
 
     # Overridable -- handle comment
     def handle_comment(self, data):

--- a/src/gocept/template_rewrite/pagetemplates.py
+++ b/src/gocept/template_rewrite/pagetemplates.py
@@ -88,8 +88,12 @@ class PythonExpressionFilter(saxutils.XMLFilterBase):
         for attr, value in attrs.items():
             if name.startswith('tal:') or attr.startswith('tal:'):
                 value = value.replace(';;', DOUBLE_SEMICOLON_REPLACEMENT)
-                attrs[attr] = re.sub(
+                rewritten_value = re.sub(
                     zpt_regex, self._rewrite_expression, value)
+                # We want to undo the replacement also in cases the regex did
+                # not match.
+                attrs[attr] = rewritten_value.replace(
+                    DOUBLE_SEMICOLON_REPLACEMENT, ';;')
 
         self._cont_handler.startElement(name, attrs, ws_dict, is_short_tag)
 

--- a/src/gocept/template_rewrite/tests/test_pagetemplates.py
+++ b/src/gocept/template_rewrite/tests/test_pagetemplates.py
@@ -118,10 +118,10 @@ def test_pagetemplates__PTParserRewriter____call____2(
     '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>''',
     # It does not change string expressions
     '''<a tal:content="string:${view/b};;3">a</a>''',
-    # It keeps the angle brackets in script tags.
-    '''<script> a <> 2 </script>''',
+    # It keeps the escapable characters in script tags.
+    '''<script> a <> 2 & 4 </script>''',
     # But also keeps entity references.
-    '''<p> a &lt;&gt; 2 </p>''',
+    '''<p> a &lt;&gt; 2 &amp; 4</p>''',
 ])
 def test_pagetemplates__PTParserRewriter____call____3(
         input, rewriter=PTParserRewriter):

--- a/src/gocept/template_rewrite/tests/test_pagetemplates.py
+++ b/src/gocept/template_rewrite/tests/test_pagetemplates.py
@@ -116,6 +116,8 @@ def test_pagetemplates__PTParserRewriter____call____2(
     ('''<p>Can we parse character references &#x34;</p> '''),
     # Processing instruction
     '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>''',
+    # It does not change string expressions
+    '''<a tal:content="string:${view/b};;3">a</a>''',
 ])
 def test_pagetemplates__PTParserRewriter____call____3(
         input, rewriter=PTParserRewriter):

--- a/src/gocept/template_rewrite/tests/test_pagetemplates.py
+++ b/src/gocept/template_rewrite/tests/test_pagetemplates.py
@@ -118,6 +118,10 @@ def test_pagetemplates__PTParserRewriter____call____2(
     '''<?xml version="1.0" encoding="UTF-8" standalone="no"?>''',
     # It does not change string expressions
     '''<a tal:content="string:${view/b};;3">a</a>''',
+    # It keeps the angle brackets in script tags.
+    '''<script> a <> 2 </script>''',
+    # But also keeps entity references.
+    '''<p> a &lt;&gt; 2 </p>''',
 ])
 def test_pagetemplates__PTParserRewriter____call____3(
         input, rewriter=PTParserRewriter):


### PR DESCRIPTION
Improve the escaping handling to keep double `;;` outside of python expressions and <, >, & inside of script tags.