### PR TITLE
Allow single quotes for attributes

### DIFF
--- a/src/gocept/template_rewrite/pagetemplates.py
+++ b/src/gocept/template_rewrite/pagetemplates.py
@@ -127,18 +127,19 @@ class HTMLGenerator(html.parser.HTMLParser):
         ws_dict = {}
         raw_attrs = []
         parse_error = False
+        # Pattern that selects both the key with preceding whitespaces and the
+        # raw value
+        patterns = [
+            r'(\s+{})="([^"]*)"',  # Double quotes
+            r"(\s+{})='([^']*)'",  # Single quotes
+            r"(\s+{})\b",  # Singleton, no value
+        ]
         for attr, value in attrs:
-            # Double quotes
-            mo = re.search(r'(\s+{})="([^"]*)"'.format(attr), full_tag,
-                           flags=re.IGNORECASE)
-            if not mo:
-                # Single quotes
-                mo = re.search(r"(\s+{})='([^']*)'".format(attr), full_tag,
+            for pattern in patterns:
+                mo = re.search(pattern.format(attr), full_tag,
                                flags=re.IGNORECASE)
-            if not mo:
-                # No value
-                mo = re.search(r"(\s+{})\b".format(attr), full_tag,
-                             flags=re.IGNORECASE)
+                if mo:
+                    break
 
             if not mo:
                 parse_error = True

--- a/src/gocept/template_rewrite/pagetemplates.py
+++ b/src/gocept/template_rewrite/pagetemplates.py
@@ -116,13 +116,6 @@ class PythonExpressionFilter(saxutils.XMLFilterBase):
         self._parent.close()
 
 
-leading_whitespace = r'(\s+{})'
-value_pattern = '''\\s+{}="([^"]*)"'''
-value_pattern_single = "\\s+{}='([^']*)'"
-# This tag end matches whitespaces and shorttag
-tag_end = r'(\s*/?>$)'
-
-
 class HTMLGenerator(html.parser.HTMLParser):
     """A HTML parser which also generates a html file."""
 
@@ -135,57 +128,32 @@ class HTMLGenerator(html.parser.HTMLParser):
         raw_attrs = []
         parse_error = False
         for attr, value in attrs:
-            # We include the '="' to ensure that we get the attribute instead
-            # of another string in the tag.
-            mo = re.search(
-                leading_whitespace.format(attr) + '(?==")', full_tag,
-                flags=re.IGNORECASE)
+            # Double quotes
+            mo = re.search(r'(\s+{})="([^"]*)"'.format(attr), full_tag,
+                           flags=re.IGNORECASE)
             if not mo:
-                # check if this is an attribute with single quotes
-                mo = re.search(
-                    leading_whitespace.format(attr) + "(?==')", full_tag,
-                    flags=re.IGNORECASE
-                )
-                if mo:
-                    mo_value = re.search(
-                        value_pattern_single.format(attr),
-                        full_tag, flags=re.IGNORECASE
-                    )
+                # Single quotes
+                mo = re.search(r"(\s+{})='([^']*)'".format(attr), full_tag,
+                               flags=re.IGNORECASE)
+            if not mo:
+                # No value
+                mo = re.search(r"(\s+{})\b".format(attr), full_tag,
+                             flags=re.IGNORECASE)
 
-                    raw_value = mo_value.group(1)
-                else:
-                    # We seem to have a attribute without `=` so we ensure
-                    # whitespaces around it and hope that the will not be
-                    # another occurrence of it.
-                    mo = re.search(
-                        leading_whitespace.format(attr) + r'(\s*)', full_tag,
-                        flags=re.IGNORECASE)
-                    raw_value = None
-            else:
-                # if we have a value it was already unescaped by the base
-                # class, but we want the raw value as this is one way to
-                # preserve `&` and `&amp;` in one string at the same time. So
-                # we have to parse the tag for the raw value here again.
-                mo_value = re.search(
-                    value_pattern.format(attr), full_tag, flags=re.IGNORECASE)
-
-                # Not sure what this intended to catch and what test case to
-                # write for it, so I comment it out until it becomes relevant
-                # again.
-
-                # if mo_value is None:
-                #     parse_error = True
-                #     break
-                raw_value = mo_value.group(1)
-
-            if mo is None:
+            if not mo:
                 parse_error = True
                 break
+
+            # The value is already unescaped, but we want the raw value as this
+            # is the only way to preserve both `&` and `&amp;` in one string at
+            # the same time.
+            raw_value = mo.group(2) if len(mo.groups()) == 2 else None
             ws_dict[attr] = mo.group(1)
             raw_attrs.append((attr, raw_value))
 
         if not parse_error:
-            mo = re.search(tag_end, full_tag)
+            # Find end tag matching whitespaces and shorttag
+            mo = re.search(r'(\s*/?>$)', full_tag)
             ws_dict[ENDTAG] = mo.group()
 
             # XXX We are deeply coupling to our generator here, as we change

--- a/src/gocept/template_rewrite/pagetemplates.py
+++ b/src/gocept/template_rewrite/pagetemplates.py
@@ -141,20 +141,22 @@ class HTMLGenerator(html.parser.HTMLParser):
                 leading_whitespace.format(attr) + '(?==")', full_tag,
                 flags=re.IGNORECASE)
             if not mo:
-                # just for good measure, check if this is an attribute with single quotes
+                # check if this is an attribute with single quotes
                 mo = re.search(
                     leading_whitespace.format(attr) + "(?==')", full_tag,
                     flags=re.IGNORECASE
                 )
                 if mo:
                     mo_value = re.search(
-                        value_pattern_single.format(attr), full_tag, flags=re.IGNORECASE)
+                        value_pattern_single.format(attr),
+                        full_tag, flags=re.IGNORECASE
+                    )
 
                     raw_value = mo_value.group(1)
                 else:
                     # We seem to have a attribute without `=` so we ensure
-                    # whitespaces around it and hope that the will not be another
-                    # occurrence of it.
+                    # whitespaces around it and hope that the will not be
+                    # another occurrence of it.
                     mo = re.search(
                         leading_whitespace.format(attr) + r'(\s*)', full_tag,
                         flags=re.IGNORECASE)

--- a/src/gocept/template_rewrite/pagetemplates.py
+++ b/src/gocept/template_rewrite/pagetemplates.py
@@ -140,8 +140,8 @@ class HTMLGenerator(html.parser.HTMLParser):
                                flags=re.IGNORECASE)
                 if mo:
                     break
-
-            if not mo:
+            else:
+                # No pattern matches
                 parse_error = True
                 break
 

--- a/src/gocept/template_rewrite/tests/test_pagetemplates.py
+++ b/src/gocept/template_rewrite/tests/test_pagetemplates.py
@@ -30,6 +30,8 @@ def rewriter():
      '<!-- Comment with triple hyphen - in the middle -->'),
     ('<!-- Comment with quadruple hyphen ---- in the middle -->',
      '<!-- Comment with quadruple hyphen  in the middle -->'),
+    # Invalid single-quotes get correctly converted to double-quotes
+    ('<p class=\'test\'></p>', '<p class="test"></p>'),
 ])
 def test_pagetemplates__PTParserRewriter____call____1(
         input, expected):


### PR DESCRIPTION
In its current implementation the template-rewriter empties xml(html)-attributes which are quoted using a single quote, although they are valid XML. 
For example:
`<input type='text'/>` will be converted to `<input type/>`

This PR adds the ability for the template rewrite to also detect these types of attributes and parse them correctly.